### PR TITLE
Remove type parameter from nodes

### DIFF
--- a/src/AddNode.js
+++ b/src/AddNode.js
@@ -4,7 +4,6 @@
   class AddNode extends TextureGen.CanvasNode {
     constructor(id) {
       super(id, 'Add', ['A', 'B']);
-      this.type = 'AddNode';
     }
 
     render() {

--- a/src/BaseNode.js
+++ b/src/BaseNode.js
@@ -9,7 +9,6 @@
 
   class BaseNode {
     constructor(id, title, inputNames) {
-      this.type = 'BaseNode';
       this.id = id;
       this.dirty = true;
       if(!inputNames) {

--- a/src/BlurNode.js
+++ b/src/BlurNode.js
@@ -4,7 +4,6 @@
   class BlurNode extends TextureGen.CanvasNode {
     constructor(id) {
       super(id, 'Blur', ['Image']);
-      this.type = 'BlurNode';
     }
 
     render() {

--- a/src/CanvasNode.js
+++ b/src/CanvasNode.js
@@ -4,7 +4,6 @@
   class CanvasNode extends TextureGen.BaseNode {
     constructor(id, title, inputNames) {
       super(id, title, inputNames);
-      this.type = 'CanvasNode';
       this.canvas = document.createElement('canvas');
       this.canvas.width = 512;
       this.canvas.height = 512;

--- a/src/CheckerNode.js
+++ b/src/CheckerNode.js
@@ -4,7 +4,6 @@
   class CheckerNode extends TextureGen.CanvasNode {
     constructor(id) {
       super(id, 'Checker', []);
-      this.type = 'CheckerNode';
     }
 
     render() {

--- a/src/CircularGradientNode.js
+++ b/src/CircularGradientNode.js
@@ -4,7 +4,6 @@
   class CircularGradientNode extends TextureGen.CanvasNode {
     constructor(id) {
       super(id, 'CircularGradient', ['x', 'y', 'radius']);
-      this.type = 'CircularGradientNode';
     }
 
     render() {

--- a/src/CircularSineNode.js
+++ b/src/CircularSineNode.js
@@ -4,7 +4,6 @@
   class CircularSineNode extends TextureGen.CanvasNode {
     constructor(id) {
       super(id, 'CircularSine', ['x', 'y', 'periods']);
-      this.type = 'CircularSineNode';
     }
 
     render() {

--- a/src/ColorNode.js
+++ b/src/ColorNode.js
@@ -22,7 +22,6 @@
   class ColorNode extends TextureGen.BaseNode {
     constructor(id) {
       super(id, 'Color', []);
-      this.type = 'ColorNode';
       this.value = {r: 255, g: 255, b: 255, a: 255};
 
       var input = document.createElement('input');

--- a/src/CubePreviewNode.js
+++ b/src/CubePreviewNode.js
@@ -39,7 +39,6 @@
         'alphamap',
         'repeat'
       ]);
-      this.type = 'CubePreviewNode';
 
       this.map = makeMapBundle();
       this.lightMap = makeMapBundle();

--- a/src/DistortXNode.js
+++ b/src/DistortXNode.js
@@ -4,7 +4,6 @@
   class DistortXNode extends TextureGen.CanvasNode {
     constructor(id) {
       super(id, 'DistortX', ['Image', 'Map', 'Amount']);
-      this.type = 'DistortXNode';
     }
 
     render() {

--- a/src/EmbossNode.js
+++ b/src/EmbossNode.js
@@ -4,7 +4,6 @@
   class EmbossNode extends TextureGen.CanvasNode {
     constructor(id) {
       super(id, 'Emboss', ['Image']);
-      this.type = 'EmbossNode';
     }
 
     render() {

--- a/src/FillNode.js
+++ b/src/FillNode.js
@@ -4,7 +4,6 @@
   class FillNode extends TextureGen.CanvasNode {
     constructor(id) {
       super(id, 'Fill', ['color']);
-      this.type = 'FillNode';
     }
 
     render() {

--- a/src/MotionBlurNode.js
+++ b/src/MotionBlurNode.js
@@ -4,7 +4,6 @@
   class MotionBlurNode extends TextureGen.CanvasNode {
     constructor(id) {
       super(id, 'MotionBlur', ['Image', 'Intensity']);
-      this.type = 'MotionBlurNode';
     }
 
     render() {

--- a/src/MultiplyNode.js
+++ b/src/MultiplyNode.js
@@ -4,7 +4,6 @@
   class MultiplyNode extends TextureGen.CanvasNode {
     constructor(id) {
       super(id, 'Multiply', ['A', 'B']);
-      this.type = 'MultiplyNode';
     }
 
     render() {

--- a/src/NodeManager.js
+++ b/src/NodeManager.js
@@ -63,7 +63,7 @@
       for(var key in this.nodes) {
         var node = this.nodes[key];
         var serializable = {};
-        serializable.type = node.type;
+        serializable.type = node.constructor.name;
         serializable.id = node.id;
         serializable.inputs = {};
         var hasNoInputs = true;

--- a/src/NumberNode.js
+++ b/src/NumberNode.js
@@ -4,7 +4,6 @@
   class NumberNode extends TextureGen.BaseNode {
     constructor(id) {
       super(id, 'Number', []);
-      this.type = 'NumberNode';
       this.value = {r: 255, g: 255, b: 255, a: 255};
 
       var input = document.createElement('input');

--- a/src/PerlinNode.js
+++ b/src/PerlinNode.js
@@ -4,7 +4,6 @@
   class PerlinNode extends TextureGen.CanvasNode {
     constructor(id) {
       super(id, 'Perlin', ['freq.', 'octaves']);
-      this.type = 'PerlinNode';
     }
 
     render() {

--- a/src/PolarNode.js
+++ b/src/PolarNode.js
@@ -4,7 +4,6 @@
   class PolarNode extends TextureGen.CanvasNode {
     constructor(id) {
       super(id, 'Polar', ['Image']);
-      this.type = 'PolarNode';
     }
 
     render() {

--- a/src/RandomNode.js
+++ b/src/RandomNode.js
@@ -4,7 +4,6 @@
   class RandomNode extends TextureGen.CanvasNode {
     constructor(id) {
       super(id, 'Random', []);
-      this.type = 'RandomNode';
     }
 
     render() {

--- a/src/RotateNode.js
+++ b/src/RotateNode.js
@@ -4,7 +4,6 @@
   class RotateNode extends TextureGen.CanvasNode {
     constructor(id) {
       super(id, 'Rotate', ['Image', 'Repeat']);
-      this.type = 'RotateNode';
     }
 
     render() {

--- a/src/SineNode.js
+++ b/src/SineNode.js
@@ -4,7 +4,6 @@
   class SineNode extends TextureGen.CanvasNode {
     constructor(id) {
       super(id, 'Sine', ['periods']);
-      this.type = 'SineNode';
     }
 
     render() {

--- a/src/SubtractNode.js
+++ b/src/SubtractNode.js
@@ -4,7 +4,6 @@
   class SubtractNode extends TextureGen.CanvasNode {
     constructor(id) {
       super(id, 'Subtract', ['A', 'B']);
-      this.type = 'SubtractNode';
     }
 
     render() {

--- a/src/ThresholdNode.js
+++ b/src/ThresholdNode.js
@@ -4,7 +4,6 @@
   class ThresholdNode extends TextureGen.CanvasNode {
     constructor(id) {
       super(id, 'Threshold', ['Image', 'Threshold']);
-      this.type = 'ThresholdNode';
     }
 
     render() {


### PR DESCRIPTION
The name of the classes is fetched directly from `this.constructor.name`
instead.
