### PR TITLE
Remove setSelectionRange code from number field

### DIFF
--- a/src/NumberNode.js
+++ b/src/NumberNode.js
@@ -20,12 +20,9 @@
     setValue(value) {
       this.value = value;
 
-      var start = this.input.selectionStart,
-          end = this.input.selectionEnd;
-
-      this.input.value = value;
-
-      this.input.setSelectionRange(start, end);
+      if (this.input.value != value) {
+        this.input.value = value;
+      }
 
       for(var key in this.outputs) {
         this.outputs[key].dirty = true;


### PR DESCRIPTION
setSelectionRange and the related properties aren't supported for
input[type="number"], so we simply refrain from updating the input value
if it is already correct instead.

This fixes a regression from #19.
