### PR TITLE
Rename scale to repeat in rotozoom

### DIFF
--- a/src/RotozoomNode.js
+++ b/src/RotozoomNode.js
@@ -27,14 +27,14 @@
           default: 0
         }),
         new TextureGen.NumberInput({
-          name: 'ScaleX',
+          name: 'RepeatX',
           min: 0,
           max: 128,
           stop: 0.01,
           default: 1
         }),
         new TextureGen.NumberInput({
-          name: 'ScaleY',
+          name: 'RepeatY',
           min: 0,
           max: 128,
           stop: 0.01,
@@ -51,9 +51,9 @@
       var angle = +this.getInput('Angle') || 0;
       var translateX = +this.getInput('TranslateX') || 0;
       var translateY = +this.getInput('TranslateY') || 0;
-      var scaleX = +this.getInput('ScaleX') || 1;
-      var scaleY = +this.getInput('ScaleY') || 1;
-      this.imageData = texturegen.rotozoom(input, angle, translateX, translateY, scaleX, scaleY);
+      var repeatX = +this.getInput('RepeatX') || 1;
+      var repeatY = +this.getInput('RepeatY') || 1;
+      this.imageData = texturegen.rotozoom(input, angle, translateX, translateY, repeatX, repeatY);
       this.ctx.putImageData(this.imageData, 0, 0);
       this.dirty = false;
 

--- a/src/texturegen-core.js
+++ b/src/texturegen-core.js
@@ -86,18 +86,18 @@ var texturegen = {};
     return imageData;
   }
 
-  texturegen.rotozoom = function(imageData, angle, translateX, translateY, scaleX, scaleY) {
+  texturegen.rotozoom = function(imageData, angle, translateX, translateY, repeatX, repeatY) {
     var resultImageData = clone(imageData);
     angle = angle / 180 * Math.PI;
     forEachPixel(resultImageData, function(x, y) {
       x -= imageData.width / 2;
       y -= imageData.height / 2;
-      x += scaleX * translateX;
-      x += scaleY * translateY;
-      var rotozoomedX = scaleX * (Math.cos(angle) * x - Math.sin(angle) * y);
-      var rotozoomedY = scaleY * (Math.sin(angle) * x + Math.cos(angle) * y);
-      rotozoomedX -= scaleX * (Math.cos(angle) * translateX - Math.sin(angle) * translateY);
-      rotozoomedY -= scaleY * (Math.sin(angle) * translateX + Math.cos(angle) * translateY);
+      x += repeatX * translateX;
+      x += repeatY * translateY;
+      var rotozoomedX = repeatX * (Math.cos(angle) * x - Math.sin(angle) * y);
+      var rotozoomedY = repeatY * (Math.sin(angle) * x + Math.cos(angle) * y);
+      rotozoomedX -= repeatX * (Math.cos(angle) * translateX - Math.sin(angle) * translateY);
+      rotozoomedY -= repeatY * (Math.sin(angle) * translateX + Math.cos(angle) * translateY);
       rotozoomedX += imageData.width / 2;
       rotozoomedY += imageData.height / 2;
       return getPixelLinear(imageData, rotozoomedX, rotozoomedY);


### PR DESCRIPTION
The way scale was implemented, a larger number meant more repetitions.
This name change reflects that functionality.
