### PR TITLE
Fix dragdrop load position bug

### DIFF
--- a/src/NodeManager.js
+++ b/src/NodeManager.js
@@ -180,6 +180,8 @@
         node.domNode.style.left = serializedNode.left;
         node.domNode.style.top = serializedNode.top;
         node.domNode.style.width = serializedNode.width;
+        node.domNode.dataset.x = serializedNode.left;
+        node.domNode.dataset.y = serializedNode.top;
         node.dirty = true;
         node.render();
       }


### PR DESCRIPTION
Now nodes will not jump around when dragged for the first time after
being loaded from JSON data.
