### PR TITLE
Store value of nodes with custom params explicitly

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
 <script src=src/GradientValue.js></script>
 <script src=src/NodeManager.js></script>
 <script src=src/BaseNode.js></script>
+<script src=src/ValueNode.js></script>
 <script src=src/LoadStoreNode.js></script>
 <script src=src/ColorNode.js></script>
 <script src=src/CanvasNode.js></script>

--- a/src/ColorNode.js
+++ b/src/ColorNode.js
@@ -19,7 +19,7 @@
     return (r + g + b).toUpperCase();
   }
 
-  class ColorNode extends TextureGen.BaseNode {
+  class ColorNode extends TextureGen.ValueNode {
     constructor(id) {
       super(id, 'Color', []);
 
@@ -50,10 +50,6 @@
         this.outputs[key].dirty = true;
         this.outputs[key].render();
       }
-    }
-
-    getOutput() {
-      return this.value.clone();
     }
   }
 

--- a/src/GradientNode.js
+++ b/src/GradientNode.js
@@ -1,12 +1,9 @@
 (function(TextureGen, $) {
   'use strict';
 
-  class GradientNode extends TextureGen.BaseNode {
+  class GradientNode extends TextureGen.ValueNode {
     constructor(id) {
       super(id, 'Gradient', []);
-      this.type = 'GradientNode';
-
-      var that = this;
 
       this.widget = document.createElement('div');
       this.widget.classList.add('gradient-widget-wrapper');
@@ -19,15 +16,15 @@
             return `${stop.color} ${stop.offset * 100}%`;
           }),
           change: function(points, styles) {
-            that.setValue(new TextureGen.GradientValue(0, 0, 512, 0, points.map(function(el) {
+            that.setValue(new TextureGen.GradientValue(0, 0, 512, 0, points.map(function(el) {
               return {offset: el.position, color: el.color};
             })), true);
           }
         });
       });
-      this.setValue(new TextureGen.GradientValue(0, 0, 512, 0, [
+      this.setValue(new TextureGen.GradientValue(0, 0, 512, 0, [
         {offset: 0, color: 'red'},
-        {offset: 0.7, color: 'orange'},      
+        {offset: 0.7, color: 'orange'},
         {offset: 1, color: 'white'}
       ]));
     }
@@ -49,10 +46,6 @@
         this.outputs[key].dirty = true;
         this.outputs[key].render();
       }
-    }
-
-    getOutput() {
-      return this.value.clone();
     }
   }
 

--- a/src/NodeManager.js
+++ b/src/NodeManager.js
@@ -137,6 +137,9 @@
         serializable.left = node.domNode.style.left;
         serializable.top = node.domNode.style.top;
         serializable.width = node.domNode.style.width;
+        if (node instanceof TextureGen.ValueNode) {
+          serializable.value = node.getOutput();
+        }
         for(var key in node.inputs) {
           if(node.inputs[key] instanceof TextureGen.GraphInput) {
             serializable.inputs[key] = node.inputs[key].value ? node.inputs[key].value.id
@@ -172,6 +175,9 @@
       for(var i = 0; i < data.nodes.length; i++) {
         var serializedNode = data.nodes[i];
         var node = this.nodes[serializedNode.id];
+        if (serializedNode.value) {
+          node.setValue(serializedNode.value);
+        }
         for(var key in serializedNode.inputs) {
           if(node.inputs[key] instanceof TextureGen.GraphInput) {
             this.connect(serializedNode.inputs[key], node.id, key);

--- a/src/ValueNode.js
+++ b/src/ValueNode.js
@@ -1,0 +1,11 @@
+(function(TextureGen) {
+  'use strict';
+
+  class ValueNode extends TextureGen.BaseNode {
+    getOutput() {
+      return this.value.clone();
+    }
+  }
+
+  TextureGen.ValueNode = ValueNode;
+})(TextureGen);


### PR DESCRIPTION
Some nodes generate their output from custom UI, which means their
output needs to be stored in order to restore them.
This is now done explicitly rather than storing the output of all nodes
with no inputs, as that may lead to unexpected problems.
