### PR TITLE
Clone imageData in texturegen.sobel

### DIFF
--- a/src/texturegen-core.js
+++ b/src/texturegen-core.js
@@ -472,6 +472,7 @@ var texturegen = {};
   };
 
   texturegen.sobel = function(imageData) {
+    imageData = clone(imageData);
     var canvas = document.createElement("canvas");
     canvas.width = imageData.width;
     canvas.height = imageData.height;


### PR DESCRIPTION
ImageData needs to be cloned to stop nodes from altering eachother's
data.
